### PR TITLE
fix missing .zshrc symlink

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -297,7 +297,7 @@ setup_zsh() {
 
     if [[ ! -d "$HOME/.oh-my-zsh" ]]; then
         info "Installing oh-my-zsh"
-        curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash
+        curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash - --keep-zshrc
     else
         info "oh-my-zsh is already installed"
     fi


### PR DESCRIPTION
Add keep-zshrc as parameter to the oh-my-zsh installation to avaid
overwriting the .zshrc file.

Fixes #3